### PR TITLE
browser: add buffer polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@gandlaf21/cashu-crypto",
+	"name": "@cashu/crypto",
 	"version": "0.2.6",
 	"description": "Basic cashu crypto functions",
 	"main": "./modules/index.js",
@@ -17,7 +17,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/gandlafbtc/cashu-crypto-ts.git"
+		"url": "git+https://github.com/cashubtc/cashu-crypto-ts.git"
 	},
 	"keywords": [
 		"blindsignature",

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -3,6 +3,7 @@ import { secp256k1 } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
 import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
 import { bytesToNumber, encodeBase64toUint8, hexToNumber } from '../util/utils.js';
+import { Buffer } from 'buffer/';
 
 export type Enumerate<N extends number, Acc extends number[] = []> = Acc['length'] extends N
 	? Acc[number]
@@ -137,10 +138,11 @@ export function deriveKeysetId(keys: MintKeys): string {
 	const pubkeysConcat = Object.entries(serializeMintKeys(keys))
 		.map(mapBigInt)
 		.sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
-		.map(([, pubKey]) => hexToBytes(pubKey)).reduce((prev,curr)=>mergeUInt8Arrays(prev,curr),new Uint8Array())
+		.map(([, pubKey]) => hexToBytes(pubKey))
+		.reduce((prev, curr) => mergeUInt8Arrays(prev, curr), new Uint8Array());
 	const hash = sha256(pubkeysConcat);
-	const hashHex =  Buffer.from(hash).toString('hex').slice(0, 14)
-	return '00' + hashHex
+	const hashHex = Buffer.from(hash).toString('hex').slice(0, 14);
+	return '00' + hashHex;
 }
 
 function mergeUInt8Arrays(a1: Uint8Array, a2: Uint8Array): Uint8Array {
@@ -149,4 +151,4 @@ function mergeUInt8Arrays(a1: Uint8Array, a2: Uint8Array): Uint8Array {
 	mergedArray.set(a1);
 	mergedArray.set(a2, a1.length);
 	return mergedArray;
-  }
+}

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -1,4 +1,5 @@
 import { bytesToHex } from '@noble/curves/abstract/utils';
+import { Buffer } from 'buffer/';
 
 export function bytesToNumber(bytes: Uint8Array): bigint {
 	return hexToNumber(bytesToHex(bytes));


### PR DESCRIPTION
# Fixes: Missing `Buffer` global in browser

## Description
Browsers do not have access to the `Buffer` global. I assume that this is the reason why this package has the `buffer` npm package in its dependencies. However this polyfill was never applied.

## Changes

- Apply `Buffer` polyfill where necesarry

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
