### PR TITLE
NUT11 sign outputs

### DIFF
--- a/src/client/NUT11.ts
+++ b/src/client/NUT11.ts
@@ -25,7 +25,7 @@ export const signP2PKsecret = (secret: Uint8Array, privateKey: PrivKey) => {
 	return sig;
 };
 
-export const signBlindedMessage = (B_: string, privateKey: PrivKey) => {
+export const signBlindedMessage = (B_: string, privateKey: PrivKey): Uint8Array => {
 	const msgHash = sha256(B_);
 	const sig = schnorr.sign(msgHash, privateKey);
 	return sig;

--- a/src/client/NUT11.ts
+++ b/src/client/NUT11.ts
@@ -29,7 +29,7 @@ export const signBlindedMessage = (B_: string, privateKey: PrivKey) => {
 	const msgHash = sha256(B_);
 	const sig = schnorr.sign(msgHash, privateKey);
 	return sig;
-}
+};
 
 export const getSignedProofs = (proofs: Array<Proof>, privateKey: string): Array<Proof> => {
 	return proofs.map((p) => {
@@ -50,11 +50,14 @@ export const getSignedOutput = (output: BlindedMessage, privateKey: PrivKey): Bl
 	const signature = signBlindedMessage(B_, privateKey);
 	output.witness = { signatures: [bytesToHex(signature)] };
 	return output;
-}
+};
 
-export const getSignedOutputs = (outputs: Array<BlindedMessage>, privateKey: string): Array<BlindedMessage> => {
-	return outputs.map(o => getSignedOutput(o, privateKey));
-}
+export const getSignedOutputs = (
+	outputs: Array<BlindedMessage>,
+	privateKey: string
+): Array<BlindedMessage> => {
+	return outputs.map((o) => getSignedOutput(o, privateKey));
+};
 
 export const getSignedProof = (proof: Proof, privateKey: PrivKey): Proof => {
 	if (!proof.witness) {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -15,6 +15,7 @@ export type BlindedMessage = {
 	B_: ProjPointType<bigint>;
 	r: bigint;
 	secret: Uint8Array;
+	witness?: Witness;
 };
 
 export function createRandomBlindedMessage(): BlindedMessage {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -21,7 +21,8 @@ export type BlindedMessage = {
 };
 
 export function createRandomBlindedMessage(privateKey?: PrivKey): BlindedMessage {
-	return blindMessage(randomBytes(32),
+	return blindMessage(
+		randomBytes(32),
 		bytesToNumber(secp256k1.utils.randomPrivateKey()),
 		privateKey
 	);
@@ -82,7 +83,7 @@ export const deserializeProof = (proof: SerializedProof): Proof => {
 		C: pointFromHex(proof.C),
 		id: proof.id,
 		secret: new TextEncoder().encode(proof.secret),
-		witness: proof.witness?JSON.parse(proof.witness):undefined
+		witness: proof.witness ? JSON.parse(proof.witness) : undefined
 	};
 };
 export const serializeBlindedMessage = (

--- a/src/common/NUT11.ts
+++ b/src/common/NUT11.ts
@@ -1,4 +1,4 @@
-import { Secret } from "./index.js";
+import { Secret } from './index.js';
 
 export const parseSecret = (secret: string | Uint8Array): Secret => {
 	try {

--- a/src/mint/NUT11.ts
+++ b/src/mint/NUT11.ts
@@ -2,6 +2,8 @@ import { schnorr } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
 import { parseSecret } from '../common/NUT11.js';
 import { Proof } from '../common/index.js';
+import { BlindedMessage } from '../client/index.js';
+import { ProjPointType } from '@noble/curves/abstract/weierstrass.js';
 
 export const verifyP2PKSig = (proof: Proof) => {
 	if (!proof.witness) {
@@ -42,3 +44,14 @@ export const verifyP2PKSig = (proof: Proof) => {
 		parsedSecret[1].data
 	);
 };
+
+export const verifyP2PKSigOutput = (output: BlindedMessage, publicKey: string) => {
+	if (!output.witness) {
+		throw new Error('could not verify signature, no witness provided');
+	}
+	return schnorr.verify(
+		output.witness.signatures[0],
+		sha256(output.B_.toHex(true)),
+		publicKey
+	)
+}

--- a/src/mint/NUT11.ts
+++ b/src/mint/NUT11.ts
@@ -45,7 +45,7 @@ export const verifyP2PKSig = (proof: Proof) => {
 	);
 };
 
-export const verifyP2PKSigOutput = (output: BlindedMessage, publicKey: string) => {
+export const verifyP2PKSigOutput = (output: BlindedMessage, publicKey: string): boolean => {
 	if (!output.witness) {
 		throw new Error('could not verify signature, no witness provided');
 	}

--- a/test/client/NUT11.test.ts
+++ b/test/client/NUT11.test.ts
@@ -3,7 +3,8 @@ import { createP2PKsecret, getSignedProof } from '../../src/client/NUT11.js';
 import { bytesToHex } from '@noble/curves/abstract/utils';
 import { Proof, pointFromHex } from '../../src/common';
 import { parseSecret } from '../../src/common/NUT11.js';
-import { verifyP2PKSig } from '../../src/mint/NUT11.js';
+import { verifyP2PKSig, verifyP2PKSigOutput } from '../../src/mint/NUT11.js';
+import { createRandomBlindedMessage } from '../../src/client/index.js';
 
 const PRIVKEY = schnorr.utils.randomPrivateKey();
 const PUBKEY = schnorr.getPublicKey(PRIVKEY);
@@ -30,6 +31,11 @@ describe('test create p2pk secret', () => {
 		};
 		const signedProof = getSignedProof(proof, PRIVKEY);
 		const verify = verifyP2PKSig(signedProof);
+		expect(verify).toBe(true);
+	});
+	test('sign and verify blindedMessage', async() => {
+		const blindedMessage = createRandomBlindedMessage(PRIVKEY);
+		const verify = verifyP2PKSigOutput(blindedMessage, bytesToHex(PUBKEY));
 		expect(verify).toBe(true);
 	});
 });


### PR DESCRIPTION
# Fixes: [this issue](https://github.com/cashubtc/cashu.me/issues/186)

## Description
Adding support for signing the outputs when needed. This is a step towards `SIG_ALL` implementation and a fix for issues when trying to redeem `SIG_ALL` tokens on cashu.me and others that use cashu-ts behind the scenes. With this functionality we can then instruct cashu-ts to sign the outputs when it finds `SIG_ALL` tags.

## Changes

- added `signBlindedMessage`, `getSignedOutput`, `getSignedOutputs`
- introduced a new optional field `witness` in `BlindedMessage`
- modified `createRandomBlindedMessage` and `blindMessage` to allow a private key to be specified as input and act accordingly.
- npm run format

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
