### PR TITLE
allow multiple private keys when signing proofs

### DIFF
--- a/test/client/NUT11.test.ts
+++ b/test/client/NUT11.test.ts
@@ -1,5 +1,5 @@
 import { schnorr } from '@noble/curves/secp256k1';
-import { createP2PKsecret, getSignedProof } from '../../src/client/NUT11.js';
+import { createP2PKsecret, getSignedProof, getSignedProofs } from '../../src/client/NUT11.js';
 import { bytesToHex } from '@noble/curves/abstract/utils';
 import { Proof, pointFromHex } from '../../src/common';
 import { parseSecret } from '../../src/common/NUT11.js';
@@ -32,6 +32,66 @@ describe('test create p2pk secret', () => {
 		const signedProof = getSignedProof(proof, PRIVKEY);
 		const verify = verifyP2PKSig(signedProof);
 		expect(verify).toBe(true);
+	});
+
+	test('sign and verify proofs', async () => {
+		const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${bytesToHex(
+			PUBKEY
+		)}"}]`;
+		const proof1: Proof = {
+			amount: 1,
+			C: pointFromHex('034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'),
+			id: '00000000000',
+			secret: new TextEncoder().encode(secretStr)
+		};
+
+		const proof2: Proof = {
+			amount: 1,
+			C: pointFromHex('034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'),
+			id: '00000000000',
+			secret: new TextEncoder().encode(secretStr)
+		};
+
+		const proofs = [proof1, proof2];
+
+		const signedProofs = getSignedProofs(proofs, bytesToHex(PRIVKEY));
+		const verify0 = verifyP2PKSig(signedProofs[0]);
+		const verify1 = verifyP2PKSig(signedProofs[1]);
+		expect(verify0).toBe(true);
+		expect(verify1).toBe(true);
+	});
+
+	test('sign and verify proofs, different keys', async () => {
+		const PRIVKEY2 = schnorr.utils.randomPrivateKey();
+		const PUBKEY2 = schnorr.getPublicKey(PRIVKEY2);
+
+		const secretStr = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${bytesToHex(
+			PUBKEY
+		)}"}]`;
+		const secretStr2 = `["P2PK",{"nonce":"76f5bf3e36273bf1a09006ef32d4551c07a34e218c2fc84958425ad00abdfe06","data":"${bytesToHex(
+			PUBKEY2
+		)}"}]`;
+		const proof1: Proof = {
+			amount: 1,
+			C: pointFromHex('034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'),
+			id: '00000000000',
+			secret: new TextEncoder().encode(secretStr)
+		};
+
+		const proof2: Proof = {
+			amount: 1,
+			C: pointFromHex('034268c0bd30b945adf578aca2dc0d1e26ef089869aaf9a08ba3a6da40fda1d8be'),
+			id: '00000000000',
+			secret: new TextEncoder().encode(secretStr2)
+		};
+
+		const proofs = [proof1, proof2];
+
+		const signedProofs = getSignedProofs(proofs, [bytesToHex(PRIVKEY), bytesToHex(PRIVKEY2)]);
+		const verify0 = verifyP2PKSig(signedProofs[0]);
+		const verify1 = verifyP2PKSig(signedProofs[1]);
+		expect(verify0).toBe(true);
+		expect(verify1).toBe(true);
 	});
 	test('sign and verify blindedMessage', async () => {
 		const blindedMessage = createRandomBlindedMessage(PRIVKEY);


### PR DESCRIPTION
# Fixes: https://github.com/cashubtc/cashu-ts/issues/179

## Description

Allow an array of private keys when signing proofs, matching with the pubkey in the secret 

## Changes

- extended method signature to allow array
- match keys if array is passed

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
