### PR TITLE
remove bip39 dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
 				"@noble/curves": "^1.6.0",
 				"@noble/hashes": "^1.5.0",
 				"@scure/bip32": "^1.5.0",
-				"@scure/bip39": "^1.4.0",
 				"buffer": "^6.0.3"
 			},
 			"devDependencies": {
@@ -1371,19 +1370,6 @@
 				"@noble/curves": "~1.6.0",
 				"@noble/hashes": "~1.5.0",
 				"@scure/base": "~1.1.7"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@scure/bip39": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.4.0.tgz",
-			"integrity": "sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==",
-			"license": "MIT",
-			"dependencies": {
-				"@noble/hashes": "~1.5.0",
-				"@scure/base": "~1.1.8"
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
 		"@noble/curves": "^1.6.0",
 		"@noble/hashes": "^1.5.0",
 		"@scure/bip32": "^1.5.0",
-		"@scure/bip39": "^1.4.0",
 		"buffer": "^6.0.3"
 	},
 	"devDependencies": {

--- a/src/client/NUT09.ts
+++ b/src/client/NUT09.ts
@@ -1,7 +1,5 @@
 import { HDKey } from '@scure/bip32';
 import { getKeysetIdInt } from '../common/index.js';
-import { generateMnemonic, mnemonicToSeedSync } from '@scure/bip39';
-import { wordlist } from '@scure/bip39/wordlists/english';
 
 const STANDARD_DERIVATION_PATH = `m/129372'/0'`;
 
@@ -36,14 +34,4 @@ const derive = (
 		throw new Error('Could not derive private key');
 	}
 	return derived.privateKey;
-};
-
-export const generateNewMnemonic = (): string => {
-	const mnemonic = generateMnemonic(wordlist, 128);
-	return mnemonic;
-};
-
-export const deriveSeedFromMnemonic = (mnemonic: string): Uint8Array => {
-	const seed = mnemonicToSeedSync(mnemonic);
-	return seed;
 };

--- a/test/client/NUT09.test.ts
+++ b/test/client/NUT09.test.ts
@@ -1,10 +1,13 @@
 import { bytesToHex } from '@noble/curves/abstract/utils';
-import { deriveSeedFromMnemonic } from '../../src/client/NUT09.js';
 import { deriveSecret } from '../../src/client/NUT09.js';
 import { HDKey } from '@scure/bip32';
 
-const mnemonic = 'half depart obvious quality work element tank gorilla view sugar picture humble';
-const seed = deriveSeedFromMnemonic(mnemonic);
+const seed = Uint8Array.from(
+	Buffer.from(
+		'dd44ee516b0647e80b488e8dcc56d736a148f15276bef588b37057476d4b2b25780d3688a32b37353d6995997842c0fd8b412475c891c16310471fbc86dcbda8',
+		'hex'
+	)
+);
 
 describe('testing hdkey from seed', () => {
 	test('hdkey from seed', async () => {


### PR DESCRIPTION
# Fixes: #7 

## Changes
- remove BIP-39 dependency
- BREAKING CHANGE: removes `generateNewMnemonic` and `deriveSeedFromMnemonic` from NUT09

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
