### PR TITLE
[FIX] Exports for NUT-12

### DIFF
--- a/src/client/NUT12.ts
+++ b/src/client/NUT12.ts
@@ -26,7 +26,7 @@ export const verifyDLEQProof = (
 	const R_2 = sB_.subtract(eC_); // R2 = sB' - eC'
 	const hash = hash_e([R_1, R_2, A, C_]); // e == hash(R1, R2, A, C')
 	return arraysEqual(hash, dleq.e);
-}
+};
 
 export const verifyDLEQProof_reblind = (
 	secret: Uint8Array, // secret
@@ -40,4 +40,4 @@ export const verifyDLEQProof_reblind = (
 	const bG = secp256k1.ProjectivePoint.fromPrivateKey(dleq.r);
 	const B_ = Y.add(bG); // Re-blind the message
 	return verifyDLEQProof(dleq, B_, C_, A);
-}
+};

--- a/src/client/NUT12.ts
+++ b/src/client/NUT12.ts
@@ -12,12 +12,12 @@ function arraysEqual(arr1: any, arr2: any) {
 	return true;
 }
 
-export function verifyDLEQProof(
+export const verifyDLEQProof = (
 	dleq: DLEQ,
 	B_: ProjPointType<bigint>,
 	C_: ProjPointType<bigint>,
 	A: ProjPointType<bigint>
-) {
+) => {
 	const sG = secp256k1.ProjectivePoint.fromPrivateKey(bytesToHex(dleq.s));
 	const eA = A.multiply(bytesToNumber(dleq.e));
 	const sB_ = B_.multiply(bytesToNumber(dleq.s));
@@ -28,12 +28,12 @@ export function verifyDLEQProof(
 	return arraysEqual(hash, dleq.e);
 }
 
-export function verifyDLEQProof_reblind(
+export const verifyDLEQProof_reblind = (
 	secret: Uint8Array, // secret
 	dleq: DLEQ,
 	C: ProjPointType<bigint>, // unblinded e-cash signature point
 	A: ProjPointType<bigint> // mint public key point
-) {
+) => {
 	if (dleq.r === undefined) throw new Error('verifyDLEQProof_reblind: Undefined blinding factor');
 	const Y = hashToCurve(secret);
 	const C_ = C.add(A.multiply(dleq.r)); // Re-blind the e-cash signature

--- a/src/mint/NUT12.ts
+++ b/src/mint/NUT12.ts
@@ -22,4 +22,4 @@ export const createDLEQProof = (B_: ProjPointType<bigint>, a: Uint8Array): DLEQ 
 	// WARNING: NON-CONSTANT TIME OPERATIONS?
 	const s = numberToBytesBE((n_r + n_e * n_a) % secp256k1.CURVE.n, 32); // (r + ea) mod n
 	return { s, e };
-}
+};

--- a/src/mint/NUT12.ts
+++ b/src/mint/NUT12.ts
@@ -9,7 +9,7 @@ import { bytesToNumber, hexToNumber } from '../util/utils.js';
  * See: https://github.com/cashubtc/cashu-crypto-ts/pull/2 for more details
  * See: https://en.wikipedia.org/wiki/Timing_attack for information about timing attacks.
  */
-export function createDLEQProof(B_: ProjPointType<bigint>, a: Uint8Array): DLEQ {
+export const createDLEQProof = (B_: ProjPointType<bigint>, a: Uint8Array): DLEQ => {
 	const r = bytesToHex(createRandomPrivateKey()); // r <- random
 	const R_1 = secp256k1.ProjectivePoint.fromPrivateKey(r); // R1 = rG
 	const R_2 = B_.multiply(hexToNumber(r)); // R2 = rB_


### PR DESCRIPTION
## Description
Exports the functions in NUT-12 in the same way as the others.
In cashu-ts Jester cannot resolve the functions in NUT-12.

## Changes

- `export function <func_name> (args...) {...}` => `export const <func_name> = (args...) => {...}`

## PR Tasks

- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
