### PR TITLE
Nut12 exports hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,8 +100,7 @@
 			"types": "./modules/mint/NUT12.d.ts",
 			"import": "./modules/esm/mint/NUT12.js",
 			"default": "./modules/mint/NUT12.js"
-		}
-		,
+		},
 		"./modules/client/NUT12": {
 			"types": "./modules/mint/NUT12.d.ts",
 			"import": "./modules/esm/mint/NUT12.js",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,17 @@
 			"types": "./modules/mint/NUT11.d.ts",
 			"import": "./modules/esm/mint/NUT11.js",
 			"default": "./modules/mint/NUT11.js"
+		},
+		"./modules/mint/NUT12": {
+			"types": "./modules/mint/NUT12.d.ts",
+			"import": "./modules/esm/mint/NUT12.js",
+			"default": "./modules/mint/NUT12.js"
+		}
+		,
+		"./modules/client/NUT12": {
+			"types": "./modules/mint/NUT12.d.ts",
+			"import": "./modules/esm/mint/NUT12.js",
+			"default": "./modules/mint/NUT12.js"
 		}
 	}
 }


### PR DESCRIPTION
# Fixes: nut12 exports were missing


- [x] Open PR
- [x] run `npm run test` --> no failing unit tests
- [x] run `npm run format`
